### PR TITLE
VDS-86: Fix error. 404 page when click 'continue browsing here' on a compare page

### DIFF
--- a/webstore-app/resources/deployment-cm.yaml
+++ b/webstore-app/resources/deployment-cm.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   ELECTRONICS_THEME_URL: https://vc3prerelease.blob.core.windows.net/packages/vc-demo-theme-default-1.3.0-alpha.955.zip
   ELECTRONICS_THEME_LOCATION: /mnt/cms-content/Themes/Electronics
-  B2B_THEME_URL: https://vc3prerelease.blob.core.windows.net/packages/vc-demo-theme-b2b-1.7.0-alpha.1603-vds-34.zip
+  B2B_THEME_URL: https://vc3prerelease.blob.core.windows.net/packages/vc-demo-theme-b2b-1.7.0-alpha.1604.zip
   B2B_THEME_LOCATION: /mnt/cms-content/Themes/B2B-store
   ASSETS_URL: https://vcbacpac.blob.core.windows.net/dac-packages/webstore_assets_2.zip
   ASSETS_LOCATION: /mnt/cms-content


### PR DESCRIPTION
Now it leads to Home page because we don't have all categories page. 