### PR TITLE
VDS-904: Implement indexation of members User Groups (member tags)

### DIFF
--- a/webstore-app/resources/deployment-cm.yaml
+++ b/webstore-app/resources/deployment-cm.yaml
@@ -184,7 +184,7 @@ data:
       {
         "Id": "VirtoCommerce.DemoSolutionFeatures",
         "Repository": "VirtoCommerce/vc-module-demo-features",
-        "PackageUrl": "https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.DemoSolutionFeaturesModule_1.9.0-alpha.261-vds-904.zip"
+        "PackageUrl": "https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.DemoSolutionFeaturesModule_1.9.0-alpha.263-vds-904.zip"
       },
       {
         "Id": "VirtoCommerce.DemoCustomerSegmentsModule",

--- a/webstore-app/resources/deployment-cm.yaml
+++ b/webstore-app/resources/deployment-cm.yaml
@@ -184,7 +184,7 @@ data:
       {
         "Id": "VirtoCommerce.DemoSolutionFeatures",
         "Repository": "VirtoCommerce/vc-module-demo-features",
-        "PackageUrl": "https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.DemoSolutionFeaturesModule_1.9.0-alpha.249-vds-873.zip"
+        "PackageUrl": "https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.DemoSolutionFeaturesModule_1.9.0-alpha.261-vds-904.zip"
       },
       {
         "Id": "VirtoCommerce.DemoCustomerSegmentsModule",


### PR DESCRIPTION
When “UserGroupsInheritance“ feature is turned on such login exists. 

- Old Groups will be cleared at member saving. These will not be saved into data storage. 
- Member tags (new user groups) will be attached to the “Group” field of the member model at getting. Therefore in the index will be shown member tags, without old user groups. And also in UI in old the “User groups“ input will be shown selected member tags list. 
- If we change any tags and member indexation is turned on member index will be rebuilt. 

If the feature is turned off old behavior takes place. 