### PR TITLE
Fix storefront dependency

### DIFF
--- a/common-base/kustomization.yaml
+++ b/common-base/kustomization.yaml
@@ -32,14 +32,14 @@ vars:
 - name: VC_NAMESPACE
   objref:
     kind: Service
-    name: storefront
+    name: platform
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace
 - name: VC_INSTANCE
   objref:
     kind: Service
-    name: storefront
+    name: platform
     apiVersion: v1
   fieldref:
     fieldpath: metadata.labels.instance


### PR DESCRIPTION
When we try to create app without storefront we have a problem with undefined variables VC_INSTANCE & VC_NAMESPACE
Value for VC_INSTANCE & VC_NAMESPACE should be taken from the existing platform service
